### PR TITLE
make sampleID a list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,16 @@
+
+## Specification Maintainers
+
+The current specification maintainers are listed below.
+
+### rnaget api
+* Sean Upchurch (@saupchurch)
+* Emilio Palumbo (@emi80)
+
+## Updating the specification
+
+Minor editorial fixes where there is no likelihood of controversy may be done directly on the **master** branch.
+Larger changes should be proposed as pull requests so that they can be discussed and refined.
+(Even those with write access to the **ga4gh-rnaseq/schema** repository should in general create their pull request branches within their own **schema** forks.
+This way when the main repository is forked again, the new fork is created with a minimum of extraneous volatile branches.)
+

--- a/rnaget.md
+++ b/rnaget.md
@@ -190,11 +190,11 @@ _optional string_
 Version to return
 </td></tr>
 <tr markdown="block"><td>
-`sampleID`
+`sampleIDList`
 </td><td>
 _optional string_  
 </td><td>
-sampleID to match
+return only values for listed comma separated samples
 </td></tr>
 <tr markdown="block"><td>
 `projectID`
@@ -215,21 +215,21 @@ study to filter by
 </td><td>
 _optional string_  
 </td><td>
-return only values for listed feature ID values
+return only values for listed comma separated feature ID values
 </td></tr>
 <tr markdown="block"><td>
 `featureNameList`
 </td><td>
 _optional string_  
 </td><td>
-return only values for listed features
+return only values for listed comma separated features
 </td></tr>
 <tr markdown="block"><td>
 `featureAccessionList`
 </td><td>
 _optional string_  
 </td><td>
-return only values for listed accession numbers
+return only values for listed comma separated accession numbers
 </td></tr>
 <tr markdown="block"><td>
 `minExpression`

--- a/rnaget.yaml
+++ b/rnaget.yaml
@@ -235,9 +235,9 @@ paths:
         items:
           type: "string"
         collectionFormat: "csv"
-      - name: "sampleID"
+      - name: "sampleIDList"
         in: "query"
-        description: "sampleID to match"
+        description: "return only values for listed sample IDs"
         required: false
         type: "string"
       - name: "projectID"


### PR DESCRIPTION
Changes sampleID to sampleIDList to make it clearer that it is to be used for slicing on the sample axis of the data matrix.  Further specifies that the slicing lists should be comma separated.