### PR TITLE
lowercase the URL response parameter and require it be https

### DIFF
--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -868,7 +868,7 @@ components:
           type: string
         studyID:
           type: string
-        URL:
+        url:
           type: string
         units:
           type: string

--- a/rnaget.md
+++ b/rnaget.md
@@ -613,8 +613,8 @@ The response to an expression query is a JSON object with the following fields:
 | `tags`     | string array | Optional | List of tags for the object |
 | `fileType` | string    | Optional | Type of file.  Examples include: loom, tsv |
 | `studyID` | string | Optional | ID of containing study |
-| `URL    ` | string | Yes      | URL to download file |
-| `headers` | object | Optional | For HTTPS URLs, the server may supply a JSON object containing one or more string key-value pairs which the client MUST supply as headers with any request to the URL. For example, if headers is `{"Authorization": "Bearer xxxx"}`, then the client must supply the header `Authorization: Bearer xxxx` with the HTTPS request to the URL. |
+| `url    ` | string | Yes      | An `https:` URL to download file |
+| `headers` | object | Optional | For HTTPS URLs, the server may supply a JSON object containing one or more string key-value pairs which the client MUST supply verbatim as headers with any request to the URL. For example, if headers is `{"Authorization": "Bearer xxxx"}`, then the client must supply the header `Authorization: Bearer xxxx` with the HTTPS request to the URL. |
 | `md5    ` | hex string | Optional | MD5 digest of the “payload” data — the url data blocks |
 
 #### An example response
@@ -622,7 +622,7 @@ The response to an expression query is a JSON object with the following fields:
 ```
 [
   {
-    "URL": "http://server.com/rnaget/E-MTAB-5423-query-results.tpms.loom",
+    "url": "https://server.com/rnaget/E-MTAB-5423-query-results.tpms.loom",
     "fileType": "loom",
     "id": "2a7ab5533ef941eaa59edbfe887b58c4",
     "studyID": "6cccbbd76b9c4837bd7342dd616d0fec",
@@ -895,15 +895,15 @@ The response to a continuous query is a JSON object with the following fields:
 | `tags`     | string array | Optional | List of tags for the object |
 | `fileType` | string    | Optional | Type of file.  Examples include: loom, tsv |
 | `studyID` | string | Optional | ID of containing study |
-| `URL    ` | string | Yes      | URL to download file |
-| `headers` | object | Optional | For HTTPS URLs, the server may supply a JSON object containing one or more string key-value pairs which the client MUST supply as headers with any request to the URL. For example, if headers is `{"Authorization": "Bearer xxxx"}`, then the client must supply the header `Authorization: Bearer xxxx` with the HTTPS request to the URL. |
+| `url    ` | string | Yes      | An `https:` URL to download file |
+| `headers` | object | Optional | For HTTPS URLs, the server may supply a JSON object containing one or more string key-value pairs which the client MUST supply verbatim as headers with any request to the URL. For example, if headers is `{"Authorization": "Bearer xxxx"}`, then the client must supply the header `Authorization: Bearer xxxx` with the HTTPS request to the URL. |
 | `md5    ` | hex string | Optional | MD5 digest of the “payload” data — the url data blocks |
 
 #### An example response
 
 ```
 { 
-  "URL": "http://server.com/rnaget/E-MTAB-5423-query-results.bw.loom",
+  "url": "https://server.com/rnaget/E-MTAB-5423-query-results.bw.loom",
   "fileType": "loom",
   "id": "2a7ab5533e33a82fbf21a30de87b58c4",
   "studyID": "6cccbbd76b9c4837bd7342dd616d0fec",


### PR DESCRIPTION
This brings the added response parameters for endpoints delivering URLs to be inline with the existing similar object used by htsget.

1) The response URL parameter is lower cased to `url`
2) The specification requires an `https:` URL
3) example updated to reflect these changes