### PR TITLE
Update operationId for /continuous/filters

### DIFF
--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -1077,7 +1077,7 @@ paths:
         - continuous
       summary: Returns filters for continuous searches
       description: To support flexible search this provides a means of discovering the search filters supported by the data provider.
-      operationId: searchContinuousFilters
+      operationId: getContinuousFilters
       responses:
         "200":
           description: successful operation


### PR DESCRIPTION
The `operationId` attribute for `/continuous/filter` is now `getContinuousFilters` for consistency with the other endpoints