### PR TITLE
Project id parameter

### DIFF
--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -916,6 +916,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: "#/components/parameters/projectIDParam"
         - $ref: "#/components/parameters/studyIDParam"
         - $ref: "#/components/parameters/versionParam"
         - $ref: "#/components/parameters/sampleIDListParam"
@@ -964,6 +965,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: "#/components/parameters/projectIDParam"
         - $ref: "#/components/parameters/studyIDParam"
         - $ref: "#/components/parameters/versionParam"
         - $ref: "#/components/parameters/sampleIDListParam"

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -602,12 +602,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: projectID
-          in: query
-          description: project to filter by
-          required: false
-          schema:
-            type: string
+        - $ref: "#/components/parameters/projectIDParam"
         - $ref: "#/components/parameters/studyIDParam"
         - $ref: "#/components/parameters/versionParam"
         - $ref: "#/components/parameters/sampleIDListParam"
@@ -655,12 +650,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: projectID
-          in: query
-          description: project to filter by
-          required: false
-          schema:
-            type: string
+        - $ref: "#/components/parameters/projectIDParam"
         - $ref: "#/components/parameters/studyIDParam"
         - $ref: "#/components/parameters/versionParam"
         - $ref: "#/components/parameters/sampleIDListParam"
@@ -1258,6 +1248,15 @@ components:
         type: string
       example:
         1.0
+    projectIDParam:
+      name: projectID
+      in: query
+      description: project to filter by
+      required: false
+      schema:
+        type: string
+      example:
+        9c0eba51095d3939437e220db196e27b
     studyIDParam:
       name: studyID
       in: query


### PR DESCRIPTION
This pull request includes the following changes:
- define a global `projectIDParam` parameter under `components`
- use the global parameter in expression endpoints replacing the local one

I also noticed that `continuous/tickets` and `continuous/bytes` does not give the possibility to filter by project ID, so there is a second commit to add `projectDparam` to continuous endpoints. If the lack of `projectID` parameter is intentional the second commit can be skipped.