### PR TITLE
Release/1.1.0

### DIFF
--- a/.spec-docs.json
+++ b/.spec-docs.json
@@ -1,0 +1,6 @@
+{
+    "apiSpecPath": "rnaget-openapi.yaml",
+    "docsRoot": "docs",
+    "defaultBranch": "master",
+    "branchPathBase": "preview"
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For the software developer, these common endpoints and patterns make it easier t
 |--------|-------------------------|--------------------------|-------------------|
 | **master**: the current release | [HTML](https://ga4gh-rnaseq.github.io/schema/master/) | [ReDoc](https://ga4gh-rnaseq.github.io/schema/master/redoc-ui.html) |<img src="http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh-rnaseq/schema/master/rnaget-openapi.yaml" /> |
 | **develop**: stable development branch | [HTML](https://ga4gh-rnaseq.github.io/schema/develop/) | [ReDoc](https://ga4gh-rnaseq.github.io/schema/develop/redoc-ui.html) |<img src="http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh-rnaseq/schema/develop/rnaget-openapi.yaml" /> |
-| **release/1.0.0**: RNAget version 1.0.0 | [HTML](https://ga4gh-rnaseq.github.io/schema/release/1.0.0/) | [ReDoc](https://ga4gh-rnaseq.github.io/schema/release/1.0.0/redoc-ui.html) |<img src="http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh-rnaseq/schema/release/1.0.0/rnaget-openapi.yaml" /> |
+| **release/1.1.0**: RNAget version 1.1.0 | | [ReDoc](https://ga4gh-rnaseq.github.io/schema/release/1.1.0/docs) |<img src="http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh-rnaseq/schema/RNAget-1.1.0/rnaget-openapi.yaml" /> |
+| **release/1.0.0**: RNAget version 1.0.0 | [HTML](https://ga4gh-rnaseq.github.io/schema/release/1.0.0/) | [ReDoc](https://ga4gh-rnaseq.github.io/schema/release/1.0.0/redoc-ui.html) |<img src="http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh-rnaseq/schema/RNAget-1.0.0/rnaget-openapi.yaml" /> |
 
 ### Testing and Compliance
 

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -727,8 +727,9 @@ paths:
       description: |
         The response is a list of the supported data formats as a JSON formatted object unless an alternative formatting supported by the server is requested.  A data provider may use any internal storage format that they wish with no restrictions from this API.  To support development of interoperable clients, it is recommended that data providers MUST support at least 1 of the following common output formats:
 
-        * Tab delimited text (.tsv)
-        * [Loom](https://linnarssonlab.org/loompy/format/index.html) (.loom)
+        * Tab delimited text (tsv)
+        * [Loom](https://linnarssonlab.org/loompy/format/index.html) (loom)
+        * [anndata](https://anndata.readthedocs.io/en/latest/) (anndata)
 
         A Tab delimited file can have any number of comment lines beginning with `#` for storing metadata.  There should be one header row following the comments.  Feature (genes/transcripts) names and/or ID fields should be the first columns of the header row and have the `string` type.  All following columns are for the samples and will have 32-bit `float` values in each row.
 
@@ -740,7 +741,9 @@ paths:
         ENSG00000000003 TSPAN6  12.4  15.6
         ```
 
-        A Loom format file will have a 32-bit `float` matrix for the expression values with samples on the column axis and features on the row axis.  Associated metadata can be stored as row and column attributes as described by loom specification.
+        A Loom format file will have a 32-bit `float` matrix for the expression values with samples on the column axis and features on the row axis.  Associated metadata can be stored as row and column attributes as described by the loom specification.
+
+        An anndata format file will have a 32-bit `float` matrix for the expression values with samples on the column axis and features on the row axis.  Associated metadata can be stored as row and column attributes as described by the anndata specification.
       operationId: getExpressionFormats
       responses:
         "200":

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -3,6 +3,8 @@ servers:
   - url: /rnaget
 info:
   title: RNAget API
+  x-logo:
+    url: https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg
   description: |
     ## Design principles
 

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -27,7 +27,7 @@ info:
 
     ## OpenAPI Description
 
-    An OpenAPI description of this specification is available and [describes the 1.0.0 version](rnaget-openapi.yaml). OpenAPI is an independent API description format for describing REST services and is compatible with a number of [third party tools](http://openapi.tools/).
+    An OpenAPI description of this specification is available and [describes the 1.1.0 version](rnaget-openapi.yaml). OpenAPI is an independent API description format for describing REST services and is compatible with a number of [third party tools](http://openapi.tools/).
 
     ## Compliance
 
@@ -45,7 +45,7 @@ info:
     Responses from the server MUST include a Content-Type header containing the encoding for the invoked method and protocol version.  Unless negotiated with the client and allowed by the server, the default encoding is:
 
     ```
-    Content-Type: application/vnd.ga4gh.rnaget.v1.0.0+json; charset=us-ascii
+    Content-Type: application/vnd.ga4gh.rnaget.v1.1.0+json; charset=us-ascii
     ```
 
     All response objects from the server are expected to be in JSON format, regardless of the response status code, unless otherwise negotiated with the client and allowed by the server.
@@ -60,8 +60,8 @@ info:
 
     When responding to a request a server MUST use the fully specified media type for that endpoint. When determining if a request is well-formed, a server MUST allow a internet type to degrade like so
 
-      - `application/vnd.ga4gh.rnaget.v1.0.0+json; charset=us-ascii`
-      - `application/vnd.ga4gh.rnaget.v1.0.0+json`
+      - `application/vnd.ga4gh.rnaget.v1.1.0+json; charset=us-ascii`
+      - `application/vnd.ga4gh.rnaget.v1.1.0+json`
       - `application/json`    
 
     ## Errors
@@ -103,9 +103,10 @@ info:
 
     ## API specification change log
 
+    1.1.0    Adds /service-info endpoint
     1.0.0    Initial release version
 
-  version: 1.0.0
+  version: 1.1.0
   contact:
     name: GA4GH RNA-seq Working Group
     email: ga4gh-rnaseq@ga4gh.org
@@ -1100,6 +1101,19 @@ paths:
       security:
         - rnaget_auth:
             - read:continuous
+  /service-info:
+    get:
+      summary: "Show information about this RNAget instance"
+      operationId: getServiceInfo
+      tags:
+        - service-info
+      responses:
+        "200":
+          description: "Use `type: org.ga4gh:RNAget:1.1.0` when implementing this specification."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Service"
 components:
   securitySchemes:
     rnaget_auth:
@@ -1240,6 +1254,25 @@ components:
         message:
           type: string
           description: Error message details
+    Service:
+      allOf:
+        - $ref: "https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service"
+        - type: object
+          properties:
+            supported:
+              $ref: "#/components/schemas/Supported"
+    Supported:
+      type: object
+      description: A true value indicates that the corresponding route is implemented by the service.  A non-implemented route should have a false value and return a 501 error to any requests.  If any boolean property is not provided, it is assumed to be implemented. If the entire supported object is not provided, all endpoints are assumed to be implemented.
+      properties:
+          projects:
+            type: boolean
+          studies:
+            type: boolean
+          expressions:
+            type: boolean
+          continuous:
+            type: boolean
   parameters:
     versionParam:
       name: version

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -200,6 +200,30 @@ tags:
     externalDocs:
       description: Find out more
       url: https://github.com/ga4gh-rnaseq/schema
+  - name: Service Info
+    description: |
+      The GA4GH Service Info specification provides a GA4GH-wide, structured format
+      for describing web services implementing GA4GH API specifications. RNAget
+      implements service info through the standard `/service-info` API endpoint,
+      and also extends the base model with additional attributes.
+
+      RNAget services MUST indicate that they support the RNAget protocol by
+      using an `artifact` value of `rnaget` in the service info `type` property.
+
+      ```
+      {
+        ...
+        "type": {
+          "group": "org.ga4gh",
+          "artifact": "rnaget",
+          "version": "1.1.0" 
+        }
+        ...
+      }
+      ```
+    externalDocs:
+      description: View the Service Info specification
+      url: https://github.com/ga4gh-discovery/ga4gh-service-info
   - name: projectModel
     x-displayName: The Project Model
     description: |
@@ -223,6 +247,7 @@ x-tagGroups:
       - studies
       - expressions
       - continuous
+      - Service Info
   - name: Models
     tags:
       - projectModel
@@ -1106,10 +1131,10 @@ paths:
       summary: "Show information about this RNAget instance"
       operationId: getServiceInfo
       tags:
-        - service-info
+        - Service Info
       responses:
         "200":
-          description: "Use `type: org.ga4gh:RNAget:1.1.0` when implementing this specification."
+          description: successful operation
           content:
             application/json:
               schema:
@@ -1259,6 +1284,12 @@ components:
         - $ref: "https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service"
         - type: object
           properties:
+            type:
+                properties:
+                    artifact:
+                        example: rnaget
+                    version:
+                        example: 1.1.0
             supported:
               $ref: "#/components/schemas/Supported"
     Supported:


### PR DESCRIPTION
Updated README with version 1.1.0 release.

A few points for clarification:
1. In the old release, we had an `HTML` column and a `ReDoc` column. The new docs tool builds documentation that fits under the `ReDoc` column, but there's nothing for the `HTML` column. We can:
- leave the HTML column blank for this and subsequent versions.
- delete the HTML column, as it will likely not be used going forward. We could also rebuild version 1.0.0 with the new tool for consistency.

2. I've remapped the swagger validation badge urls to Github releases rather than Github branches (for branches release/1.0.0 and release/1.1.0). Reason for this is I think we will want to close the release branches, instead using github releases to tag specific versions. [gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) expects release branches to be deleted after merged into `master`. For `master` and `develop` we can leave as is, as these are longstanding branches.