### PR TITLE
add advice to limit return matrix size

### DIFF
--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -95,6 +95,9 @@ info:
 
     GA4GH is publishing a [CORS best practices document](https://docs.google.com/document/d/1Ifiik9afTO-CEpWGKEZ5TlixQ6tiKcvug4XLd9GNcqo/edit?usp=sharing), which implementers should refer to for guidance when enabling CORS on public API instances.
 
+    ## Filtering Results
+    Some endpoints describe optional filters to select and limit the results returned.  Requests supplying none of the filters may return large amounts of data and expose the data provider to the risk of Denial of Service (DOS) attacks.  Implementors SHOULD limit the size of return matrices to an appropriate value which their server can support.
+
     ## Possible Future API Enhancements
 
     - Allow OR for search filters

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -96,7 +96,7 @@ info:
     GA4GH is publishing a [CORS best practices document](https://docs.google.com/document/d/1Ifiik9afTO-CEpWGKEZ5TlixQ6tiKcvug4XLd9GNcqo/edit?usp=sharing), which implementers should refer to for guidance when enabling CORS on public API instances.
 
     ## Filtering Results
-    Some endpoints describe optional filters to select and limit the results returned.  Requests supplying none of the filters may return large amounts of data and expose the data provider to the risk of Denial of Service (DOS) attacks.  Implementors SHOULD limit the size of return matrices to an appropriate value which their server can support.
+    Some endpoints describe optional filters to select and limit the results returned.  Requests supplying none of the filters may return large amounts of data and expose the data provider to the risk of Distributed Denial of Service (DDoS) attacks.  Implementors SHOULD limit the size of return matrices to an appropriate value which their server can support.
 
     ## Possible Future API Enhancements
 


### PR DESCRIPTION
Add comment to implementors advising them to self-limit the size of return matrices.  Specifically points out case where lack of any filters may return a large matrix to requests.