### PR TITLE
Feature/issue 106 build with gh openapi docs

### DIFF
--- a/.spec-docs.json
+++ b/.spec-docs.json
@@ -1,11 +1,14 @@
 {
-  "apiSpecPath": "rnaget-openapi.yaml",
   "docsRoot": "docs",
   "defaultBranch": "master",
   "branchPathBase": "preview",
-  "enabledBranchPatterns": [
-    "^master$",
-    "^develop$",
-    "^release/.+"
+  "redocTheme": "ga4gh",
+  "buildPages": [
+      {
+          "apiSpecPath": "./rnaget-openapi.yaml",
+          "htmlOutfile": "index.html",
+          "yamlOutfile": "openapi.yaml",
+          "jsonOutfile": "openapi.json"
+      }
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+env:
+  global:
+    - GH_URL=https://raw.githubusercontent.com
+    - FILE_TO_VALIDATE=rnaget-openapi.yaml
+    - URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
+
 branches:
   only:
     - master
@@ -10,11 +16,6 @@ jobs:
     - stage: validate_spec
       jdk:
         - openjdk11
-      env:
-        global:
-          - GH_URL=https://raw.githubusercontent.com
-          - FILE_TO_VALIDATE=rnaget-openapi.yaml
-          - URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
       before_install:
         - git clone --branch=v1.1.0 https://github.com/mcupak/oas-validator.git
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,38 @@
-git:
-  depth: false
-language: java
-dist: bionic
-sudo: false
-jdk:
-  - openjdk11
-services:
-  - docker
-env:
-  global:
-    - GH_URL=https://raw.githubusercontent.com
-    - FILE_TO_VALIDATE=rnaget-openapi.yaml
-    - URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
-before_install:
-  - git clone --branch=v1.1.0 https://github.com/mcupak/oas-validator.git
-script:
-  - ./oas-validator/validate.sh "$URL_TO_VALIDATE"
-after_success:
-  - docker image pull ga4gh/gh-openapi-docs:0.2.1 && docker run -v `pwd`:/usr/src/repo --env PR_BUILD=${TRAVIS_PULL_REQUEST} --env TRAVIS_BRANCH=${TRAVIS_BRANCH} --env GH_PAGES_NAME=${GH_PAGES_NAME} --env GH_PAGES_EMAIL=${GH_PAGES_EMAIL} --env GH_PAGES_TOKEN=${GH_PAGES_TOKEN} ga4gh/gh-openapi-docs:0.2.1
+branches:
+  only:
+    - master
+    - develop
+    - /^feature\/issue-\d+(-\S*)?$/
+    - "/^release\\/\\d+\\.\\d+(\\.\\d+)?$/"
+
+jobs:
+  include:
+    - stage: validate_spec
+      jdk:
+        - openjdk11
+      env:
+        global:
+          - GH_URL=https://raw.githubusercontent.com
+          - FILE_TO_VALIDATE=rnaget-openapi.yaml
+          - URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
+      before_install:
+        - git clone --branch=v1.1.0 https://github.com/mcupak/oas-validator.git
+      script:
+        - ./oas-validator/validate.sh "$URL_TO_VALIDATE"
+
+    - stage: build_docs
+      language: node_js
+      node_js:
+        - "12"
+      before_script:
+        - npm install -g @redocly/openapi-cli && npm install -g redoc-cli
+        - npm install -g @ga4gh/gh-openapi-docs@0.2.2-rc3
+      script:
+        - gh-openapi-docs
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        keep_history: true
+        github-token: $GITHUB_TOKEN
+        on:
+          all_branches: true

--- a/rnaget-openapi.yaml
+++ b/rnaget-openapi.yaml
@@ -1,128 +1,123 @@
 openapi: 3.0.0
-servers:
-  - url: /rnaget
 info:
   title: RNAget API
-  description: |
-    ## Design principles
-
-    This API provides a means of retrieving data from several types of RNA experiments including:
-
-    * Feature-level expression data from RNA-seq type measurements
-    * Coordinate-based signal/intensity data similar to a bigwig representation
-
-    via a client/server model.
-
-    Features of this API include:
-
-    * Support for a hierarchical data model which provides the option for servers to associate expression data for discovery and retrieval
-    * Support for accessing subsets of expression data through slicing operations on the expression matrix and/or query filters to specify features to be included
-    * Support for accessing signal/intensity data by specifying a range of genomic coordinates to be included
-
-    Out of the scope of this API are:
-
-    * A means of retrieving primary (raw) read sequence data. Input samples are identified in expression output and data servers should implement additional API(s) to allow for search and retrieval of raw reads. The [htsget API](https://samtools.github.io/hts-specs/htsget.html) is designed for retrieval of read data.
-    * A means of retrieving reference sequences. Servers should implement additional API(s) to allow for search and retrieval of reference base sequences. The [refget API](https://samtools.github.io/hts-specs/refget.html) is designed for retrieval of references sequences.
-    * A means of retrieving feature annotation details. Expression matrices provide the identity of each mapped feature. Servers should implement additional API(s) to allow for search and retrieval of genomic feature annotation details.
-
-    ## OpenAPI Description
-
-    An OpenAPI description of this specification is available and [describes the 1.2.0 version](rnaget-openapi.yaml). OpenAPI is an independent API description format for describing REST services and is compatible with a number of [third party tools](http://openapi.tools/).
-
-    ## Compliance
-
-    Implementors can check if their RNAget implementations conform to the
-    specification by using our [compliance suite](https://github.com/ga4gh-rnaseq/rnaget-compliance-suite).
-
-    ## Protocol essentials
-
-    All API invocations are made to a configurable HTTPS endpoint, receive URL-encoded query string parameters and HTTP headers, and return text or other allowed formatting as requested by the user. Queries containing [unsafe or reserved](https://www.ietf.org/rfc/rfc1738.txt) characters in the URL, including but not limited to "&", "/", "#", MUST encode all such characters.  Successful requests result with HTTP status code 200 and have the appropriate text encoding in the response body as defined for each endpoint. The server may provide responses with chunked transfer encoding. The client and server may mutually negotiate HTTP/2 upgrade using the standard mechanism.
-
-    HTTP responses may be compressed using [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html) transfer-coding, not content-coding.
-
-    HTTP response may include a 3XX response code and Location header redirecting the client to retrieve expression data from an alternate location as specified by [RFC 7231](https://tools.ietf.org/html/rfc7231), clients SHOULD be configured to follow redirects. `302`, `303` and `307` are all valid response codes to use.
-
-    Responses from the server MUST include a Content-Type header containing the encoding for the invoked method and protocol version.  Unless negotiated with the client and allowed by the server, the default encoding is:
-
-    ```
-    Content-Type: application/vnd.ga4gh.rnaget.v1.2.0+json; charset=us-ascii
-    ```
-
-    All response objects from the server are expected to be in JSON format, regardless of the response status code, unless otherwise negotiated with the client and allowed by the server.
-
-    Object IDs are intended for persistent retrieval of their respective objects.  An object ID MUST uniquely identify an object within the scope of a single data server.  It is beyond the scope of this API to enforce uniqueness of ID among different data servers.  IDs are strings made up of uppercase and lowercase letters, decimal digits, hypen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986 § 2.3](https://tools.ietf.org/html/rfc3986#section-2.3).
-
-    Endpoints are described as HTTPS GET methods which will be sufficient for most queries.  Queries containing multiple metadata filters may approach or exceed the URL length limits.  To handle these types of queries it is recommended that servers SHOULD implement parallel HTTPS POST endpoints accepting the same URL parameters as a UTF8-encoded JSON key-value dictionary.
-
-    When processing requests containing multiple filters and filters with lists of items, the data provider MUST use a logical `AND` for selecting the results to return.
-
-    ## Internet Media Types Handling
-
-    When responding to a request a server MUST use the fully specified media type for that endpoint. When determining if a request is well-formed, a server MUST allow a internet type to degrade like so
-
-      - `application/vnd.ga4gh.rnaget.v1.2.0+json; charset=us-ascii`
-      - `application/vnd.ga4gh.rnaget.v1.2.0+json`
-      - `application/json`    
-
-    ## Errors
-
-    The server MUST respond with an appropriate HTTP status code (4xx or 5xx) when an error condition is detected. In the case of transient server errors (e.g., 503 and other 5xx status codes), the client SHOULD implement appropriate retry logic. For example, if a client sends an alphanumeric string for a parameter that is specified as unsigned integer the server MUST reply with `Bad Request`.
-
-    | Error type        | HTTP status code | Description
-    |-------------------|------------------|-------------|
-    | `Bad Request`     | 400 | Cannot process due to malformed request, the requested parameters do not adhere to the specification |
-    | `Unauthorized`    | 401 | Authorization provided is invalid |
-    | `Not Found`       | 404 | The resource requested was not found |
-    | `Not Acceptable`  | 406 | The requested formatting is not supported by the server |
-    | `Not Implemented` | 501 | The specified request is not supported by the server |
-
-    ## Security
-
-    The RNAget API can be used to retrieve potentially sensitive genomic data and is dependent on the implementation.  Effective security measures are essential to protect the integrity and confidentiality of these data.
-
-    Sensitive information transmitted on public networks, such as access tokens and human genomic data, MUST be protected using Transport Level Security (TLS) version 1.2 or later, as specified in [RFC 5246](https://tools.ietf.org/html/rfc5246).
-
-    If the data holder requires client authentication and/or authorization, then the client's HTTPS API request MUST present an OAuth 2.0 bearer access token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750), in the Authorization request header field with the Bearer authentication scheme:
-
-    ```
-    Authorization: Bearer [access_token]
-    ```
-
-    Data providers SHOULD verify user identity and credentials.  The policies and processes used to perform user authentication and authorization, and the means through which access tokens are issued, are beyond the scope of this API specification. GA4GH recommends the use of the OAuth 2.0 framework ([RFC 6749](https://tools.ietf.org/html/rfc6749)) for authentication and authorization.  It is also recommended that implementations of this standard also implement and follow the GA4GH [Authentication and Authorization Infrastructure (AAI) standard](https://docs.google.com/document/d/1zzsuNtbNY7agPRjfTe6gbWJ3BU6eX19JjWRKvkFg1ow).
-
-    ## CORS
-    Cross-origin resource sharing (CORS) is an essential technique used to overcome the same origin content policy seen in browsers. This policy restricts a webpage from making a request to another website and leaking potentially sensitive information. However the same origin policy is a barrier to using open APIs. GA4GH open API implementers should enable CORS to an acceptable level as defined by their internal policy. For any public API implementations should allow requests from any server.
-
-    GA4GH is publishing a [CORS best practices document](https://docs.google.com/document/d/1Ifiik9afTO-CEpWGKEZ5TlixQ6tiKcvug4XLd9GNcqo/edit?usp=sharing), which implementers should refer to for guidance when enabling CORS on public API instances.
-
-    ## Filtering Results
-    Some endpoints describe optional filters to select and limit the results returned.  Requests supplying none of the filters may return large amounts of data and expose the data provider to the risk of Distributed Denial of Service (DDoS) attacks.  Implementors SHOULD limit the size of return matrices to an appropriate value which their server can support.
-
-    ## Possible Future API Enhancements
-
-    - Allow OR for search filters
-    - Report size of download file
-    - Matrix slicing with bool array or list of indices
-
-    ## API specification change log
-
-    1.2.0    Adds parameters and endpoint to specify matrix units
-             Add sample filtering by min and/or max values
-    1.1.0    Adds /service-info endpoint
-    1.0.0    Initial release version
-
   version: 1.2.0
+  x-logo:
+    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
   contact:
     name: GA4GH RNA-seq Working Group
     email: ga4gh-rnaseq@ga4gh.org
   license:
     name: Apache 2.0
     url: https://github.com/ga4gh-rnaseq/schema/blob/master/LICENSE
+servers:
+  - url: /rnaget
 externalDocs:
   description: Find out more about GA4GH
   url: http://ga4gh.org
 tags:
-  - name: projects
+  # Overview
+  - name: Design Principles
+    description: |
+      This API provides a means of retrieving data from several types of RNA experiments including:
+
+      * Feature-level expression data from RNA-seq type measurements
+      * Coordinate-based signal/intensity data similar to a bigwig representation
+
+      via a client/server model.
+
+      Features of this API include:
+
+      * Support for a hierarchical data model which provides the option for servers to associate expression data for discovery and retrieval
+      * Support for accessing subsets of expression data through slicing operations on the expression matrix and/or query filters to specify features to be included
+      * Support for accessing signal/intensity data by specifying a range of genomic coordinates to be included
+
+      Out of the scope of this API are:
+
+      * A means of retrieving primary (raw) read sequence data. Input samples are identified in expression output and data servers should implement additional API(s) to allow for search and retrieval of raw reads. The [htsget API](https://samtools.github.io/hts-specs/htsget.html) is designed for retrieval of read data.
+      * A means of retrieving reference sequences. Servers should implement additional API(s) to allow for search and retrieval of reference base sequences. The [refget API](https://samtools.github.io/hts-specs/refget.html) is designed for retrieval of references sequences.
+      * A means of retrieving feature annotation details. Expression matrices provide the identity of each mapped feature. Servers should implement additional API(s) to allow for search and retrieval of genomic feature annotation details.
+  - name: OpenAPI Description
+    description: |
+      An OpenAPI description of this specification is available and [describes the 1.2.0 version](rnaget-openapi.yaml). OpenAPI is an independent API description format for describing REST services and is compatible with a number of [third party tools](http://openapi.tools/).
+  - name: Compliance
+    description: |
+      Implementors can check if their RNAget implementations conform to the
+      specification by using our [compliance suite](https://github.com/ga4gh-rnaseq/rnaget-compliance-suite).
+  - name: Protocol Essentials
+    description: |
+      All API invocations are made to a configurable HTTPS endpoint, receive URL-encoded query string parameters and HTTP headers, and return text or other allowed formatting as requested by the user. Queries containing [unsafe or reserved](https://www.ietf.org/rfc/rfc1738.txt) characters in the URL, including but not limited to "&", "/", "#", MUST encode all such characters.  Successful requests result with HTTP status code 200 and have the appropriate text encoding in the response body as defined for each endpoint. The server may provide responses with chunked transfer encoding. The client and server may mutually negotiate HTTP/2 upgrade using the standard mechanism.
+
+      HTTP responses may be compressed using [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html) transfer-coding, not content-coding.
+
+      HTTP response may include a 3XX response code and Location header redirecting the client to retrieve expression data from an alternate location as specified by [RFC 7231](https://tools.ietf.org/html/rfc7231), clients SHOULD be configured to follow redirects. `302`, `303` and `307` are all valid response codes to use.
+
+      Responses from the server MUST include a Content-Type header containing the encoding for the invoked method and protocol version.  Unless negotiated with the client and allowed by the server, the default encoding is:
+
+      ```
+      Content-Type: application/vnd.ga4gh.rnaget.v1.2.0+json; charset=us-ascii
+      ```
+
+      All response objects from the server are expected to be in JSON format, regardless of the response status code, unless otherwise negotiated with the client and allowed by the server.
+
+      Object IDs are intended for persistent retrieval of their respective objects.  An object ID MUST uniquely identify an object within the scope of a single data server.  It is beyond the scope of this API to enforce uniqueness of ID among different data servers.  IDs are strings made up of uppercase and lowercase letters, decimal digits, hypen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986 § 2.3](https://tools.ietf.org/html/rfc3986#section-2.3).
+
+      Endpoints are described as HTTPS GET methods which will be sufficient for most queries.  Queries containing multiple metadata filters may approach or exceed the URL length limits.  To handle these types of queries it is recommended that servers SHOULD implement parallel HTTPS POST endpoints accepting the same URL parameters as a UTF8-encoded JSON key-value dictionary.
+
+      When processing requests containing multiple filters and filters with lists of items, the data provider MUST use a logical `AND` for selecting the results to return.
+  - name: Internet Media Types Handling
+    description: |
+      When responding to a request a server MUST use the fully specified media type for that endpoint. When determining if a request is well-formed, a server MUST allow a internet type to degrade like so
+
+      - `application/vnd.ga4gh.rnaget.v1.2.0+json; charset=us-ascii`
+      - `application/vnd.ga4gh.rnaget.v1.2.0+json`
+      - `application/json`
+  - name: Errors
+    description: |
+      The server MUST respond with an appropriate HTTP status code (4xx or 5xx) when an error condition is detected. In the case of transient server errors (e.g., 503 and other 5xx status codes), the client SHOULD implement appropriate retry logic. For example, if a client sends an alphanumeric string for a parameter that is specified as unsigned integer the server MUST reply with `Bad Request`.
+
+      | Error type        | HTTP status code | Description
+      |-------------------|------------------|-------------|
+      | `Bad Request`     | 400 | Cannot process due to malformed request, the requested parameters do not adhere to the specification |
+      | `Unauthorized`    | 401 | Authorization provided is invalid |
+      | `Not Found`       | 404 | The resource requested was not found |
+      | `Not Acceptable`  | 406 | The requested formatting is not supported by the server |
+      | `Not Implemented` | 501 | The specified request is not supported by the server |
+  - name: Security
+    description: |
+      The RNAget API can be used to retrieve potentially sensitive genomic data and is dependent on the implementation.  Effective security measures are essential to protect the integrity and confidentiality of these data.
+
+      Sensitive information transmitted on public networks, such as access tokens and human genomic data, MUST be protected using Transport Level Security (TLS) version 1.2 or later, as specified in [RFC 5246](https://tools.ietf.org/html/rfc5246).
+
+      If the data holder requires client authentication and/or authorization, then the client's HTTPS API request MUST present an OAuth 2.0 bearer access token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750), in the Authorization request header field with the Bearer authentication scheme:
+
+      ```
+      Authorization: Bearer [access_token]
+      ```
+
+      Data providers SHOULD verify user identity and credentials.  The policies and processes used to perform user authentication and authorization, and the means through which access tokens are issued, are beyond the scope of this API specification. GA4GH recommends the use of the OAuth 2.0 framework ([RFC 6749](https://tools.ietf.org/html/rfc6749)) for authentication and authorization.  It is also recommended that implementations of this standard also implement and follow the GA4GH [Authentication and Authorization Infrastructure (AAI) standard](https://docs.google.com/document/d/1zzsuNtbNY7agPRjfTe6gbWJ3BU6eX19JjWRKvkFg1ow).
+  - name: CORS
+    description: |
+      Cross-origin resource sharing (CORS) is an essential technique used to overcome the same origin content policy seen in browsers. This policy restricts a webpage from making a request to another website and leaking potentially sensitive information. However the same origin policy is a barrier to using open APIs. GA4GH open API implementers should enable CORS to an acceptable level as defined by their internal policy. For any public API implementations should allow requests from any server.
+
+      GA4GH is publishing a [CORS best practices document](https://docs.google.com/document/d/1Ifiik9afTO-CEpWGKEZ5TlixQ6tiKcvug4XLd9GNcqo/edit?usp=sharing), which implementers should refer to for guidance when enabling CORS on public API instances.
+  - name: Filtering Results
+    description: |
+      Some endpoints describe optional filters to select and limit the results returned.  Requests supplying none of the filters may return large amounts of data and expose the data provider to the risk of Distributed Denial of Service (DDoS) attacks.  Implementors SHOULD limit the size of return matrices to an appropriate value which their server can support.
+  - name: Possible Future API Enhancements
+    description: |
+      - Allow OR for search filters
+      - Report size of download file
+      - Matrix slicing with bool array or list of indices
+  - name: API Specification Change Log
+    description: |
+      1.2.0    Adds parameters and endpoint to specify matrix units
+               Add sample filtering by min and/or max values
+      1.1.0    Adds /service-info endpoint
+      1.0.0    Initial release version
+
+  # Interface
+  - name: Projects
     description: |
       The project is the top level of the model hierarchy and contains a set of related studies.  Example projects include:
 
@@ -131,7 +126,7 @@ tags:
     externalDocs:
       description: Find out more
       url: https://github.com/ga4gh-rnaseq/schema
-  - name: studies
+  - name: Studies
     description: |
       The study is a set of related RNA expression values.  It is assumed all samples in a study have been processed uniformly.  Example studies include:
 
@@ -140,7 +135,7 @@ tags:
     externalDocs:
       description: Find out more
       url: https://github.com/ga4gh-rnaseq/schema
-  - name: expressions
+  - name: Expressions
     description: |
       The expression is a matrix of calculated expression values.
 
@@ -200,7 +195,7 @@ tags:
     externalDocs:
       description: Find out more
       url: https://github.com/ga4gh-rnaseq/schema
-  - name: continuous
+  - name: Continuous
     description: Continuous is a matrix of coordinate range based signal data
     externalDocs:
       description: Find out more
@@ -229,29 +224,44 @@ tags:
     externalDocs:
       description: View the Service Info specification
       url: https://github.com/ga4gh-discovery/ga4gh-service-info
+
+  # Models
   - name: projectModel
-    x-displayName: The Project Model
+    x-displayName: Project
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/project" />
   - name: studyModel
-    x-displayName: The Study Model
+    x-displayName: Study
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/study" />
   - name: filterModel
-    x-displayName: The Filter Model
+    x-displayName: Filter
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/filter" />
   - name: ticketModel
-    x-displayName: The Ticket Model
+    x-displayName: Ticket
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/ticket" />
 x-tagGroups:
+  - name: Overview
+    tags:
+      - Design Principles
+      - OpenAPI Description
+      - Compliance
+      - Protocol Essentials
+      - Internet Media Types Handling
+      - Errors
+      - Security
+      - CORS
+      - Filtering Results
+      - Possible Future API Enhancements
+      - API Specification Change Log
   - name: Interface
     tags:
-      - projects
-      - studies
-      - expressions
-      - continuous
+      - Projects
+      - Studies
+      - Expressions
+      - Continuous
       - Service Info
   - name: Models
     tags:
@@ -263,7 +273,7 @@ paths:
   "/projects/{projectId}":
     get:
       tags:
-        - projects
+        - Projects
       summary: Get a single project by ID
       description: Returns the project matching the provided ID
       operationId: getProjectById
@@ -311,7 +321,7 @@ paths:
   /projects:
     get:
       tags:
-        - projects
+        - Projects
       summary: Returns a list of projects matching filters
       description: Get a list of projects matching filters
       operationId: getProjects
@@ -350,7 +360,7 @@ paths:
   /projects/filters:
     get:
       tags:
-        - projects
+        - Projects
       summary: Returns filters for project searches
       description: To support flexible search this provides a means of discovering the search filters supported by the data provider.
       operationId: getProjectFilters
@@ -387,7 +397,7 @@ paths:
   "/studies/{studyId}":
     get:
       tags:
-        - studies
+        - Studies
       summary: Get a single study by ID
       description: Returns the study matching the provided ID
       operationId: getStudyById
@@ -435,7 +445,7 @@ paths:
   /studies:
     get:
       tags:
-        - studies
+        - Studies
       summary: Returns a list of studies matching filters
       description: Get a list of studies matching filters
       operationId: getStudies
@@ -474,7 +484,7 @@ paths:
   /studies/filters:
     get:
       tags:
-        - studies
+        - Studies
       summary: Returns filters for study searches
       description: To support flexible search this provides a means of discovering the search filters supported by the data provider.
       operationId: getStudyFilters
@@ -511,7 +521,7 @@ paths:
   "/expressions/{expressionId}/ticket":
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Get specific expression data ticket
       description: Returns a ticket to download a single specified expression matrix
       operationId: getExpressionTicketById
@@ -565,7 +575,7 @@ paths:
   "/expressions/{expressionId}/bytes":
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Get specific expression data file
       description: Returns a single specified expression matrix
       operationId: getExpressionFileById
@@ -628,7 +638,7 @@ paths:
   /expressions/ticket:
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Get a ticket to download expression data
       description: Returns a download ticket for expression data matching filters
       operationId: getExpressionTicket
@@ -679,7 +689,7 @@ paths:
   /expressions/bytes:
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Download expression data matching filters
       description: Returns an expression data file matching filters
       operationId: getExpressionFile
@@ -739,7 +749,7 @@ paths:
   /expressions/formats:
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Get output formats
       description: |
         The response is a list of the supported data formats as a JSON formatted object unless an alternative formatting supported by the server is requested.  A data provider may use any internal storage format that they wish with no restrictions from this API.  To support development of interoperable clients, it is recommended that data providers MUST support at least 1 of the following common output formats:
@@ -795,7 +805,7 @@ paths:
   /expressions/filters:
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Returns filters for expression searches
       description: To support flexible search this provides a means of discovering the search filters supported by the data provider.
       operationId: getExpressionFilters
@@ -840,7 +850,7 @@ paths:
   /expressions/units:
     get:
       tags:
-        - expressions
+        - Expressions
       summary: Get output units
       description: The response is a list of the supported expression units as a JSON formatted object unless an alternative formatting supported by the server is requested.  This request is intended to be implemented by data providers who wish to support delivery of expression data in multiple units such as TPM, FPKM and/or counts.
       operationId: getExpressionUnits
@@ -877,7 +887,7 @@ paths:
   "/continuous/{continuousId}/ticket":
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Get specific continuous data ticket
       description: Returns a ticket to download a single specified continuous matrix
       operationId: getContinuousTicketById
@@ -928,7 +938,7 @@ paths:
   "/continuous/{continuousId}/bytes":
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Get specific continuous data file
       description: Returns a single specified continuous matrix
       operationId: getContinuousFileById
@@ -988,7 +998,7 @@ paths:
   /continuous/ticket:
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Get a ticket to download continuous data
       description: Returns a download ticket for continuous data  matching filters
       operationId: getContinuousTicket
@@ -1037,7 +1047,7 @@ paths:
   /continuous/bytes:
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Download continuous data matching filters
       description: Returns a continuous data file matching filters
       operationId: getContinuousFile
@@ -1095,7 +1105,7 @@ paths:
   /continuous/formats:
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Get output formats
       description: |
         The response is a list of the supported data formats as a JSON formatted object unless an alternative formatting supported by the server is requested.  A data provider may use any internal storage format that they wish with no restrictions from this API.  To support development of interoperable clients, it is recommended that data providers MUST support at least 1 of the following common output formats:
@@ -1149,7 +1159,7 @@ paths:
   /continuous/filters:
     get:
       tags:
-        - continuous
+        - Continuous
       summary: Returns filters for continuous searches
       description: To support flexible search this provides a means of discovering the search filters supported by the data provider.
       operationId: getContinuousFilters


### PR DESCRIPTION
Issue: #106 
Built Docs: https://ga4gh-rnaseq.github.io/schema/preview/feature/issue-106-build-with-gh-openapi-docs/docs/

This PR aims to largely automate the documentation build phase of the RNAget spec. Travis CI builds run the `gh-openapi-docs` tool, and deploy the resulting built documentation to the `gh-pages` branch, thereby updating the docs site. This is the same approach that is being taken by the Cloud Work Stream in DRS and WES.

Some restructuring of section names and tags was introduced to better display section names in the built doc pages.

Open Questions:
* Should we include a "contributing guidelines" doc in the repo to outline the process of creating branches and previewing docs?
* Some of the markdown content in the repo (e.g. rna_seq_design_notes.md) could be useful as an appendix to the main doc page, or as it's own doc that gets built according to the same layout + theme. Currently, some of this content is not too visible. Should we expand the documentation that gets built to include these supporting markdown files?
